### PR TITLE
Updates to use Watson Java SDK

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -8,22 +8,15 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="src/main/config"/>
 	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="src/main/scripts"/>
 	<classpathentry kind="src" path="src/main/webapp"/>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
 		<attributes>
 			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
-		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/pom.xml
+++ b/pom.xml
@@ -501,16 +501,16 @@
             <artifactId>guava</artifactId>
             <version>18.0</version>
         </dependency>
-        <dependency>
-        	<groupId>com.ibm.watson.developer_cloud</groupId>
-        	<artifactId>java-wrapper</artifactId>
-        	<version>1.1.1</version>
-        </dependency>
          <dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
 			<version>1.10.19</version>
 			<scope>test</scope>
 		</dependency>
+         <dependency>
+         	<groupId>com.ibm.watson.developer_cloud</groupId>
+         	<artifactId>java-sdk</artifactId>
+         	<version>2.7.0</version>
+         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Update the sample to make use of the Watson Java SDK rather than the
Watson Java Wrapper. This removes the needs for bluemix credential
parsing since the Java SDK does it.